### PR TITLE
Move meta variables from flask_monitor to setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+V. 0.2.2
+========
+
+- correction statd by sujaymansingh
+
 V. 0.2.1
 ========
 

--- a/flask_monitor/__init__.py
+++ b/flask_monitor/__init__.py
@@ -5,7 +5,7 @@
     Module flask_monitor
 """
 
-__version_info__ = (0, 2, 1)
+__version_info__ = (0, 2, 2)
 __version__ = '.'.join([str(val) for val in __version_info__])
 
 __namepkg__ = "flask-monitor"

--- a/flask_monitor/__init__.py
+++ b/flask_monitor/__init__.py
@@ -5,13 +5,6 @@
     Module flask_monitor
 """
 
-__version_info__ = (0, 2, 1)
-__version__ = '.'.join([str(val) for val in __version_info__])
-
-__namepkg__ = "flask-monitor"
-__desc__ = "Flask Monitor module"
-__urlpkg__ = "https://github.com/fraoustin/flask-monitor.git"
-__entry_points__ = {}
 
 from flask_monitor.main import *
 from flask_monitor.log import ObserverLog as ObserverLog 

--- a/flask_monitor/statsd.py
+++ b/flask_monitor/statsd.py
@@ -25,7 +25,7 @@ class ObserverStatsd(ObserverMetrics):
 
     def action(self, event):
         try:
-            self.client.timing(self._format.format(**event.flat), event.delta)
+            self.client.timing(self._format.format(**event.flat), event.timing)
         except Exception as e:
             self.logger.critical("Error Unknow on Statsd '%s'" % str(e))
             

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,13 @@
 import os
 from setuptools import setup, find_packages
 
-import flask_monitor as mypkg
+__version_info__ = (0, 2, 2)
+__version__ = '.'.join([str(val) for val in __version_info__])
 
-NAME = mypkg.__namepkg__
-VERSION = mypkg.__version__
-DESC = mypkg.__desc__
-URLPKG = mypkg.__urlpkg__
+__namepkg__ = "flask-monitor"
+__desc__ = "Flask Monitor module"
+__urlpkg__ = "https://github.com/fraoustin/flask-monitor.git"
+__entry_points__ = {}
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -33,16 +34,16 @@ with open('AUTHORS.txt') as f:
     AUTHORS_EMAIL = ','.join([i.split('::')[1] for i in DATA])
 
 setup(
-    name=NAME,
-    version=VERSION,
+    name=__namepkg__,
+    version=__version__,
     packages=find_packages(),
     author=AUTHORS,
     author_email=AUTHORS_EMAIL,
-    description=DESC,
+    description=__desc__,
     long_description=LONG_DESC,
     include_package_data=True,
     install_requires=REQUIRED,
-    url=URLPKG,
+    url=__urlpkg__,
     classifiers=CLASSIFIED,
-    entry_points=mypkg.__entry_points__
+    entry_points=__entry_points__
 )


### PR DESCRIPTION
If setup.py has to import flask_monitor, then it also has to import
flask.

Which means that flask already has to be present in order to install it
(or even build the package).

The meta variables are only used by setup.py, so they should really live
in the setup.py file.